### PR TITLE
Create /var/log/app directory in container

### DIFF
--- a/lib/runner
+++ b/lib/runner
@@ -8,6 +8,9 @@ cd $HOME
 # Generate supervisord.conf:
 bash /build/procfile-to-supervisord /app/Procfile /SCALE > supervisord.conf
 
+# Create /var/log/app directory
+mkdir -p /var/log/app
+
 # Display the generated supervisord.conf:
 echo "Generated supervisord.conf:"
 cat -n supervisord.conf


### PR DESCRIPTION
The plugin currently errors out because the app folder doesn't exist.
