### PR TITLE
Skip supervisord if no Procfile is present in app.

### DIFF
--- a/post-release
+++ b/post-release
@@ -8,6 +8,12 @@ set -e
 PLUGIN_DIR=$(dirname $0)
 . "$PLUGIN_DIR/lib/helpers"
 
+# Check for Procfile
+id=$(docker run -d $IMAGE test -f app/Procfile)
+if [ $(docker wait $id) -ne 0 ]; then
+  exit 0
+fi
+
 copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /build/procfile-to-supervisord
 if [ -f "$SCALE_FILE" ]; then
   echo "Found SCALE file: $SCALE_FILE"


### PR DESCRIPTION
I used the same approach like in statianzo/dokku-shoreman#2 to skip supervisord if the application has no Procfile.
This can happen e.g. for PHP applications. If supervisord is being used for other apps, deployment of apps without a Procfile fails.
