### PR TITLE
Dont run unscaled processes

### DIFF
--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -62,6 +62,11 @@ cat "$PROCFILE" | while read line; do
 
   if [ -f "$SCALEFILE" ]; then
     SCALE=$(grep "$NAME=" "$SCALEFILE")
+    if [ -z "$SCALE" ]; then
+      echo "Not running $NAME as absent in SCALE file" >&2
+      continue
+    fi
+
     NUM_PROCS=${SCALE#*=}
     if [ ! "$NUM_PROCS" -ge 1 ]; then
       echo "Invalid scale line for process $NAME: $SCALE" 1>&2

--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -68,9 +68,9 @@ cat "$PROCFILE" | while read line; do
     fi
 
     NUM_PROCS=${SCALE#*=}
-    if [ ! "$NUM_PROCS" -ge 1 ]; then
-      echo "Invalid scale line for process $NAME: $SCALE" 1>&2
-      exit 1
+    if [ "$NUM_PROCS" -eq 0 ]; then
+      echo "Not running $NAME as scale is zero" >&2
+      continue
     fi
   fi
 


### PR DESCRIPTION
I use [dokku-app-predeploy-tasks](https://github.com/michaelshobbs/dokku-app-predeploy-tasks) to run any processes with a scale of zero pre deploy, but this plugin treats zero scale as an error when I think it should just not run the process (ditto for processes absent in the SCALE file).

This also means if I want to temporarily stop my worker processes I can scale to zero:

```
dokku scale web=1 worker=0
```