### PR TITLE
Fix incompatibility with latest progrium/buildstep

### DIFF
--- a/lib/runner
+++ b/lib/runner
@@ -6,7 +6,7 @@ hash -r
 cd $HOME
 
 # Generate supervisord.conf:
-bash /build/procfile-to-supervisord /app/Procfile /app/SCALE > supervisord.conf
+bash /usr/local/bin/procfile-to-supervisord /app/Procfile /app/SCALE > supervisord.conf
 
 # Create /var/log/app directory
 mkdir -p /var/log/app

--- a/post-release
+++ b/post-release
@@ -14,7 +14,7 @@ if [ $(docker wait $id) -ne 0 ]; then
   exit 0
 fi
 
-copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /build/procfile-to-supervisord
+copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /usr/local/bin/procfile-to-supervisord
 if [ -f "$SCALE_FILE" ]; then
   echo "Found SCALE file: $SCALE_FILE"
   copy_to_container "$SCALE_FILE" /app/SCALE


### PR DESCRIPTION
Since progrium/buildstep@d771c3b18940db1d940d0c79573ba423b2331397, the `/build/` directory in the docker image is removed at the end of the build process. This fix copies `procfile-to-supervisord` to another directory.