### PR TITLE
fix buildstep compatibility issues as of 01/07/2015

### DIFF
--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -38,7 +38,7 @@ fi
 
 cat << EOF
 [program:${NAME}]
-command=/exec sh -c '${COMMAND}'
+command=/exec '${COMMAND}'
 process_name:${PROCESS_NAME}
 numprocs=${NUM_PROCS}
 autostart=true

--- a/lib/runner
+++ b/lib/runner
@@ -6,7 +6,7 @@ hash -r
 cd $HOME
 
 # Generate supervisord.conf:
-bash /build/procfile-to-supervisord /app/Procfile /app/SCALE > supervisord.conf
+bash /usr/local/bin/procfile-to-supervisord /app/Procfile /app/SCALE > supervisord.conf
 
 # Create /var/log/app directory
 mkdir -p /var/log/app

--- a/post-release
+++ b/post-release
@@ -14,7 +14,7 @@ if [ $(docker wait $id) -ne 0 ]; then
   exit 0
 fi
 
-copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /build/procfile-to-supervisord
+copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /usr/local/bin/procfile-to-supervisord
 if [ -f "$SCALE_FILE" ]; then
   echo "Found SCALE file: $SCALE_FILE"
   copy_to_container "$SCALE_FILE" /app/SCALE

--- a/post-release
+++ b/post-release
@@ -33,7 +33,7 @@ fi
 
 # Unlink /exec from /start
 # Original builstep uses `ln -nsf /start /exec` that forks supervisor repeatedly
-id=$(docker run -i -a stdin $IMAGE /bin/bash -c "rm -f /exec && cp -f /start /exec")
+id=$(docker run -i -a stdin $IMAGE /bin/bash -c "if [[ -L /exec ]];then rm -f /exec && cp -f /start /exec; fi")
 test $(docker wait $id) -eq 0
 docker commit $id $IMAGE > /dev/null
 

--- a/post-release
+++ b/post-release
@@ -31,6 +31,12 @@ else
   docker commit $id $IMAGE > /dev/null
 fi
 
+# Unlink /exec from /start
+# Original builstep uses `ln -nsf /start /exec` that forks supervisor repeatedly
+id=$(docker run -i -a stdin $IMAGE /bin/bash -c "rm -f /exec && cp -f /start /exec")
+test $(docker wait $id) -eq 0
+docker commit $id $IMAGE > /dev/null
+
 # Replace /start with our custom runner:
 id=$(cat "$PLUGIN_DIR/lib/runner" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /start")
 test $(docker wait $id) -eq 0


### PR DESCRIPTION
 - unlinks `/exec` from `/start` and copies `/start` to `/exec` so we don't fork loop on `/start` and don't clobber the original contents of `/exec` (ex. `dokku run`)
 - calls `/exec` without `sh -c` (see https://github.com/progrium/buildstep/blob/42bd9f4aab6c29041c0854c1af742215242a7318/builder/builder#L65)
 - includes PR #15

 closes #18
 closes #15