### PR TITLE
Allow environment variable to dictate which Procfile entries to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: test test-default test-run-filter
+
+PROCFILE_PATH := "/tmp/Procfile"
+SCALE_FILE_PATH := "/tmp/SCALE"
+
+test: test-default test-run-filter
+
+test-default:
+	@$(MAKE) setup-procfile setup-scale-file
+	@echo testing defaults
+	@$(QUIET) [[ `bash lib/procfile-to-supervisord $(PROCFILE_PATH) $(SCALE_FILE_PATH) | grep "\[progra" | wc -l` -eq 4 ]] || exit 1
+	@echo test succeeded
+	@$(MAKE) clean
+
+test-run-filter:
+	@$(MAKE) setup-procfile setup-scale-file
+	@echo testing DOKKU_SUPERVISOR_RUN
+	@$(QUIET) [[ `unset DOKKU_SUPERVISOR_RUN; DOKKU_SUPERVISOR_RUN="web lowlatencyworker" bash lib/procfile-to-supervisord $(PROCFILE_PATH) $(SCALE_FILE_PATH) | grep "\[progra" | wc -l` -eq 2 ]] || exit 1
+	@echo test succeeded
+	@$(MAKE) clean
+
+setup-procfile:
+	@echo "web: run webserver" > $(PROCFILE_PATH)
+	@echo "assets: build assets" >> $(PROCFILE_PATH)
+	@echo "db-migrate: migrate db" >> $(PROCFILE_PATH)
+	@echo "urgentworker: run urgentworker" >> $(PROCFILE_PATH)
+	@echo "worker: run worker" >> $(PROCFILE_PATH)
+	@echo "lowlatencyworker: run lowlatencyworker" >> $(PROCFILE_PATH)
+
+setup-scale-file:
+	@echo "web=1" > $(SCALE_FILE_PATH)
+	@echo "worker=1" >> $(SCALE_FILE_PATH)
+	@echo "urgentworker=1" >> $(SCALE_FILE_PATH)
+	@echo "assets=0" >> $(SCALE_FILE_PATH)
+	@echo "db-migrate=0" >> $(SCALE_FILE_PATH)
+
+clean:
+	@$(QUIET) rm -f $(PROCFILE_PATH) $(SCALE_FILE_PATH)

--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -53,24 +53,39 @@ gen_supervisor_conf
 
 while read line || [ -n "$line" ]
 do
-  if [ ! -n "$line" ]; then
-    continue
-  fi
-
+  [[ -z "$line" ]] && continue
+  RUN_PROC=false
   NAME=${line%%:*}
   COMMAND=${line#*: }
   NUM_PROCS=1
 
-  if [ -f "$SCALEFILE" ]; then
-    SCALE=$(grep "$NAME=" "$SCALEFILE")
-    NUM_PROCS=${SCALE#*=}
-    if [ ! "$NUM_PROCS" -ge 1 ]; then
-      echo "Invalid scale line for process $NAME: $SCALE" 1>&2
-      exit 1
+  if [[ -f "$SCALEFILE" ]]; then
+    SCALE=$(egrep "^$NAME=" "$SCALEFILE")
+    if [[ -n "$SCALE" ]]; then
+      NUM_PROCS=${SCALE#*=}
+      if [[ "$NUM_PROCS" -eq 0 ]]; then
+        echo "=====> Not running $NAME as scale is zero" >&2
+        continue
+      fi
     fi
   fi
 
-  # Add a blank line in between processes:
-  echo ""
-  gen_supervisor_proc_conf "$NAME" "$COMMAND" "$NUM_PROCS"
+  if [[ -n "$DOKKU_SUPERVISOR_RUN" ]]; then
+    for PROC in $DOKKU_SUPERVISOR_RUN; do
+      if [[ "$PROC" = "$NAME" ]]; then
+        RUN_PROC=true
+        break
+      fi
+    done
+  else
+    RUN_PROC=true
+  fi
+
+  if [[ "$NUM_PROCS" -ge 1 ]]; then
+    if [[ "$RUN_PROC" = "true" ]];then
+      # Add a blank line in between processes:
+      echo ""
+      gen_supervisor_proc_conf "$NAME" "$COMMAND" "$NUM_PROCS"
+    fi
+  fi
 done < "$PROCFILE"

--- a/lib/start
+++ b/lib/start
@@ -5,6 +5,16 @@ export HOME=/app
 hash -r
 cd $HOME
 
+# source in app env for things like DOKKU_SUPERVISOR_RUN
+if [[ -d /app/.profile.d ]]; then
+  for file in /app/.profile.d/*.sh; do
+    source $file
+  done
+fi
+# need to unset PYTHON vars to use apt installed supervisord
+unset PYTHONHOME
+unset PYTHONPATH
+
 # Generate supervisord.conf:
 bash /usr/local/bin/procfile-to-supervisord /app/Procfile /app/SCALE > supervisord.conf
 


### PR DESCRIPTION
This allows a user to set $DOKKU_SUPERVISOR_RUN to a space separated list of Procfile entries to run on a given dokku host.

Example:
  We have a single repo that contains code for a web app and supporting async tasks. We don't want to necessarily split the repo up as there would be significant overlap. This allows us deploy the same code and only run the `web` process on the web instances and the `worker` processes on the `worker` instances.

 - additionally this includes a rudimentary testing "suite"
 - also allows SCALE=0 to not error out and fail deployment