### PR TITLE
supervisord does not expand shell variables, we need to call out to a shell

### DIFF
--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -42,7 +42,7 @@ fi
 
 cat << EOF
 [program:${NAME}]
-command=/exec ${COMMAND}
+command=/exec sh -c "${COMMAND}"
 process_name:${PROCESS_NAME}
 numprocs=${NUM_PROCS}
 autostart=true


### PR DESCRIPTION
I'm not sure why, but:

```
-command=/exec sh -c '${COMMAND}'
+command=/exec ${COMMAND}
```

Was included as part of https://github.com/sehrope/dokku-logging-supervisord/commit/70f5ea273ec6dc5d2f809315fed6985779ecd913. This is an incorrect change as supervisord does not perform shell expansion of variables included in COMMAND.

So something simple like:

```
bundle exec rackup -p $PORT
```

fails with the current behaviour.