### PR TITLE
Runs the Docker container commands in detached mode

### DIFF
--- a/lib/helpers
+++ b/lib/helpers
@@ -28,7 +28,7 @@ function copy_to_container() {
 function run_in_container () {
   COMMAND="$1"
   log_debug "Executing command in container: $COMMAND"
-  id=$(docker run -i -a stdin $IMAGE /bin/bash -c "$COMMAND")
+  id=$(docker run -d $IMAGE /bin/bash -c "$COMMAND")
   test $(docker wait $id) -eq 0
   docker commit $id $IMAGE > /dev/null
 }


### PR DESCRIPTION
On my machine, this fixes sehrope/dokku-logging-supervisord#32.  Conceptually, it makes sense to me even though I'm by no means a Docker expert.  "run -d" returns immediately from Docker and provides the container ID.  The next line waits until the container command exits.